### PR TITLE
The colon throws off the guess bot

### DIFF
--- a/bots/randit_bot.js
+++ b/bots/randit_bot.js
@@ -158,7 +158,7 @@ class RanditBot {
     const message = `<@${user}> You've started a game.
       \ Your actions are ${actions.join(", ")}.
       \ Attempt a guess by writing \`<@${this.botId}> ${guessWord} {action}\`\n
-      \ ${beginWord}: ${actions.join(", ")}`
+      \ ${beginWord} ${actions.join(", ")}`
 
     this.send(message, channel)
   }


### PR DESCRIPTION
The colon in the randit message ends up being part of the first command. This fixes that.