### PR TITLE
The word reward in the message splits the string early

### DIFF
--- a/bots/randit_bot.js
+++ b/bots/randit_bot.js
@@ -168,7 +168,7 @@ class RanditBot {
 
     this.send(preMessage, channel)
 
-    let messagePreamble = "...and you were rewarded!"
+    let messagePreamble = "...and you were awarded!"
     if (reward == 0) {
         messagePreamble = "...and nothing was gained."
     }


### PR DESCRIPTION
The reward message was being split early, causing the guess bot to not understand the rewarded points. This fixes that.